### PR TITLE
Use `window-total-width' to calculate available width.

### DIFF
--- a/smart-mode-line.el
+++ b/smart-mode-line.el
@@ -685,8 +685,8 @@ name."
 It comes into play when `sml/mode-width' is set to 'full.
 
 This is necessary because the mode-line width (which we need but
-don't have acess to) is larger than the `window-width' (which we
-have access to).
+don't have acess to) is larger than `window-total-width' (which
+we have access to).
 
 Decrease this if right indentation seems to be going too far (or
 if you just want to fine-tune it)."
@@ -1438,7 +1438,7 @@ duplicated buffer names) from being displayed."
   "Return the size available for filling."
   (max 0
        (+ sml/extra-filler
-          (- (window-width)
+          (- (window-total-width)
              (let ((sml/simplified t))
                (length (format-mode-line mode-line-format)))))))
 


### PR DESCRIPTION
Despite its name, `window-width` doesn't actually return the window width. Rather, it returns the text width without taking fringes, margins, scroll bar and right divider into account. Since the mode line usually occupies the entire window width, including the fringes, margins, and scroll bar, using `window-total-width` makes more sense.

The effect is especially visible when using some minor mode that uses the left and right fringes to restrict the text width to a particular maximum in wide windows for buffers that use `visual-line-mode`. (Something I do in my `writeroom-mode` package, but I’ve seen other packages do the same). If the fringes are very wide, using `window-width` has the strange effect that the minor mode list is truncated even though there is enough space available on the mode line and the info in `mode-line-misc-info` is not displayed at the window’s right edge as it normally is.
